### PR TITLE
To be compatible with #5 "TypeError: cannot pickle '_cffi_backend.FFI' object"

### DIFF
--- a/fastapi_cloudauth/base.py
+++ b/fastapi_cloudauth/base.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Optional, Any, Type
 import requests
-from jose import jwk, jwt
 from copy import deepcopy
+from jose import jwk, jwt
 from jose.utils import base64url_decode
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials

--- a/fastapi_cloudauth/base.py
+++ b/fastapi_cloudauth/base.py
@@ -126,6 +126,16 @@ class TokenVerifier(BaseTokenVerifier):
     async def __call__(
         self, http_auth: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Optional[bool]:
+        """User access-token verification Shortcut to pass it into dependencies.
+        Use as (`auth` is this instanse and `app` is fastapi.FastAPI instanse):
+        ```
+        from fastapi import Depends
+
+        @app.get("/", dependencies=[Depends(auth)])
+        def api():
+            return "hello"
+        ```
+        """
         is_verified = self.verify_token(http_auth)
         if not is_verified:
             return None
@@ -157,6 +167,16 @@ class TokenUserInfoGetter(BaseTokenVerifier):
     async def __call__(
         self, http_auth: HTTPAuthorizationCredentials = Depends(HTTPBearer())
     ) -> Optional[Type[BaseModel]]:
+        """Get current user and verification with ID-token Shortcut.
+        Use as (`Auth` is this subclass, `auth` is `Auth` instanse and `app` is fastapi.FastAPI instanse):
+        ```
+        from fastapi import Depends
+
+        @app.get("/")
+        def api(current_user: Auth = Depends(auth)):
+            return current_user
+        ```
+        """
         is_verified = self.verify_token(http_auth)
         if not is_verified:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ black = "^19.10b0"
 uvicorn = "^0.11.8"
 botocore = "^1.17.32"
 boto3 = "^1.14.32"
+authlib = "^0.15.2"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -12,6 +12,22 @@ def test_raise_error_invalid_set_scope():
     assert raised, "raise AttributeError for invalid instanse attributes wrt scope"
 
 
+def test_return_instance_with_scope():
+    # scope method return new instance to give it for Depends.
+    verifier = TokenVerifier(jwks=JWKS(keys=[]))
+    # must set scope_key (Inherit TokenVerifier and override scope_key attribute)
+    scope_key = "dummy key"
+    verifier.scope_key = scope_key
+
+    scope_name = "required-scope"
+    obj = verifier.scope(scope_name)
+    assert isinstance(obj, TokenVerifier)
+    assert obj.scope_key == scope_key, "scope_key mustn't be cleared."
+    assert obj.scope_name == scope_name, "Must set scope_name in returned instanse."
+    assert obj.jwks_to_key == verifier.jwks_to_key, "return cloned objects"
+    assert obj.auto_error == verifier.auto_error, "return cloned objects"
+
+
 def test_forget_def_user_info():
     try:
         error_check = False


### PR DESCRIPTION
This PR resolves "TypeError: cannot pickle '_cffi_backend.FFI' object" (#5) when you use `fastapi-cloudauth` with `authlib` (probably not only for it).

This error occurred because in this case the jwks related object could not be pickled (deepcopied). I don't know why `authlib` changes whether the object can be pickled (deepcopy) or not, but the object is no longer pickled.