### PR TITLE
Store Firebase JWKS expiry and refresh keys when they expire

### DIFF
--- a/fastapi_cloudauth/base.py
+++ b/fastapi_cloudauth/base.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from datetime import datetime
 from typing import Any, Dict, List, Optional, Type, Union
 
 from fastapi import Depends, HTTPException
@@ -77,7 +76,7 @@ class CloudAuth(ABC):
             else:
                 return None
 
-        is_verified = self.verifier.verify_token(http_auth)
+        is_verified = await self.verifier.verify_token(http_auth)
         if not is_verified:
             return None
 
@@ -112,7 +111,6 @@ class UserInfoAuth(CloudAuth):
             auto_error=self.auto_error,
             extra=extra,
         )
-        self._keys_expire = jwks.expires
 
     @property
     def verifier(self) -> JWKsVerifier:
@@ -147,12 +145,6 @@ class UserInfoAuth(CloudAuth):
         clone.user_info = schema
         return clone
 
-    async def refresh_keys(self) -> None:
-        """Refresh the JWKS keys. Called when the JWKS is expired.
-        Does nothing by default. Override this method to implement key refreshing.
-        """
-        pass
-
     async def call(
         self, http_auth: HTTPAuthorizationCredentials
     ) -> Optional[Union[BaseModel, Dict[str, Any]]]:
@@ -167,11 +159,6 @@ class UserInfoAuth(CloudAuth):
         ```
         """
         claims: Dict[str, Any] = jwt.get_unverified_claims(http_auth.credentials)
-
-        if self._keys_expire:
-            current_time = datetime.now(tz=self._keys_expire.tzinfo)
-            if current_time >= self._keys_expire:
-                await self.refresh_keys()
 
         if not self.user_info:
             return claims

--- a/fastapi_cloudauth/firebase.py
+++ b/fastapi_cloudauth/firebase.py
@@ -1,14 +1,39 @@
 from calendar import timegm
 from datetime import datetime
-from typing import Any, Dict
+from email.utils import parsedate_to_datetime
+from typing import Any, Dict, Optional
 
+import requests
 from fastapi import HTTPException
+from jose import jwk
+from jose.backends.base import Key
 from pydantic import BaseModel, Field
 from starlette import status
 
 from .base import UserInfoAuth
 from .messages import NOT_VERIFIED
-from .verification import JWKS, ExtraVerifier
+from .verification import JWKS as BaseJWKS
+from .verification import ExtraVerifier
+
+
+class JWKS(BaseJWKS):
+    def _construct(self, jwks: Dict[str, Any]) -> Dict[str, Key]:
+        return {
+            kid: jwk.construct(publickey, algorithm="RS256")
+            for kid, publickey in jwks.items()
+        }
+
+    def _set_expiration(self, resp: requests.Response) -> Optional[datetime]:
+        expires_header = resp.headers.get("expires")
+        if expires_header:
+            try:
+                return parsedate_to_datetime(expires_header)
+            except ValueError:
+                # Guard against an invalid header value and do not set an expiry.
+                # This won't happen unless Firebase messes up...
+                return None
+        else:
+            return None
 
 
 class FirebaseClaims(BaseModel):
@@ -22,12 +47,10 @@ class FirebaseCurrentUser(UserInfoAuth):
     """
 
     user_info = FirebaseClaims
-    firebase_keys_url = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
 
     def __init__(self, project_id: str, *args: Any, **kwargs: Any):
-        self._key_refresh_locked = False
-        jwks = JWKS.firebase(self.firebase_keys_url)
-
+        url = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+        jwks = JWKS(url=url)
         super().__init__(
             jwks,
             *args,
@@ -37,31 +60,6 @@ class FirebaseCurrentUser(UserInfoAuth):
             extra=FirebaseExtraVerifier(project_id=project_id),
             **kwargs,
         )
-
-    async def refresh_keys(self) -> None:
-        if not self._key_refresh_locked:
-            # Ensure only one key refresh can happen at once.
-            # This prevents a dogpile of requests the second the keys expire
-            # from causing a bunch of refreshes (each one is an http request).
-            self._key_refresh_locked = True
-
-            # Re-query the keys from firebase.
-            # NOTE: The expires comes from an http header which is supposed to
-            # be set to a time long before the keys are no longer in use.
-            # This allows gradual roll-out of the keys and should prevent any
-            # request from failing.
-            # The only scenario which will result in failing requests is if
-            # there are zero requests for the entire duration of the roll-out
-            # (observed to be around 1 week), followed by a burst of multiple
-            # requests at once.
-            jwks = JWKS.firebase(self.firebase_keys_url)
-
-            # Reset the keys and the expiry date.
-            self._verifier._jwks_to_key = jwks.keys
-            self._keys_expire = jwks.expires
-
-            # Remove the lock.
-            self._key_refresh_locked = False
 
 
 class FirebaseExtraVerifier(ExtraVerifier):

--- a/fastapi_cloudauth/firebase.py
+++ b/fastapi_cloudauth/firebase.py
@@ -25,6 +25,7 @@ class FirebaseCurrentUser(UserInfoAuth):
     firebase_keys_url = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
 
     def __init__(self, project_id: str, *args: Any, **kwargs: Any):
+        self._key_refresh_locked = False
         jwks = JWKS.firebase(self.firebase_keys_url)
 
         super().__init__(
@@ -36,6 +37,31 @@ class FirebaseCurrentUser(UserInfoAuth):
             extra=FirebaseExtraVerifier(project_id=project_id),
             **kwargs,
         )
+
+    async def refresh_keys(self) -> None:
+        if not self._key_refresh_locked:
+            # Ensure only one key refresh can happen at once.
+            # This prevents a dogpile of requests the second the keys expire
+            # from causing a bunch of refreshes (each one is an http request).
+            self._key_refresh_locked = True
+
+            # Re-query the keys from firebase.
+            # NOTE: The expires comes from an http header which is supposed to
+            # be set to a time long before the keys are no longer in use.
+            # This allows gradual roll-out of the keys and should prevent any
+            # request from failing.
+            # The only scenario which will result in failing requests is if
+            # there are zero requests for the entire duration of the roll-out
+            # (observed to be around 1 week), followed by a burst of multiple
+            # requests at once.
+            jwks = JWKS.firebase(self.firebase_keys_url)
+
+            # Reset the keys and the expiry date.
+            self._verifier._jwks_to_key = jwks.keys
+            self._keys_expire = jwks.expires
+
+            # Remove the lock.
+            self._key_refresh_locked = False
 
 
 class FirebaseExtraVerifier(ExtraVerifier):

--- a/fastapi_cloudauth/firebase.py
+++ b/fastapi_cloudauth/firebase.py
@@ -22,10 +22,10 @@ class FirebaseCurrentUser(UserInfoAuth):
     """
 
     user_info = FirebaseClaims
+    firebase_keys_url = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
 
     def __init__(self, project_id: str, *args: Any, **kwargs: Any):
-        url = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
-        jwks = JWKS.firebase(url)
+        jwks = JWKS.firebase(self.firebase_keys_url)
 
         super().__init__(
             jwks,

--- a/fastapi_cloudauth/verification.py
+++ b/fastapi_cloudauth/verification.py
@@ -70,8 +70,15 @@ class JWKS:
         get and parse json into jwks from endpoint for Firebase,
         """
         response = requests.get(url)
-        if "expires" in response.headers:
-            expires = parsedate_to_datetime(response.headers["expires"])
+        expires_header = response.headers.get("expires")
+        expires: Optional[datetime]
+        if expires_header:
+            try:
+                expires = parsedate_to_datetime(expires_header)
+            except ValueError:
+                # Guard against an invalid header value and do not set an expiry.
+                # This won't happen unless Firebase messes up...
+                expires = None
         else:
             expires = None
         certs = response.json()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -10,7 +10,7 @@ from fastapi_cloudauth.verification import JWKS
 @pytest.mark.unittest
 def test_raise_error_invalid_set_scope():
     # scope_key is not declaired
-    token_verifier = ScopedAuth(jwks=JWKS(keys=[]))
+    token_verifier = ScopedAuth(jwks=JWKS.null())
     with pytest.raises(AttributeError):
         # raise AttributeError for invalid instanse attributes wrt scope
         token_verifier.scope("read:test")
@@ -19,7 +19,7 @@ def test_raise_error_invalid_set_scope():
 @pytest.mark.unittest
 def test_return_instance_with_scope():
     # scope method return new instance to give it for Depends.
-    verifier = ScopedAuth(jwks=JWKS(keys=[]))
+    verifier = ScopedAuth(jwks=JWKS.null())
     # must set scope_key (Inherit ScopedAuth and override scope_key attribute)
     scope_key = "dummy key"
     verifier.scope_key = scope_key
@@ -32,9 +32,7 @@ def test_return_instance_with_scope():
     assert obj.verifier.scope_name == set(
         [scope_name]
     ), "Must convert scope name into set."
-    assert (
-        obj.verifier._jwks_to_key == verifier.verifier._jwks_to_key
-    ), "return cloned objects"
+    assert obj.verifier._jwks == verifier.verifier._jwks, "return cloned objects"
     assert (
         obj.verifier.auto_error == verifier.verifier.auto_error
     ), "return cloned objects"
@@ -54,7 +52,7 @@ def test_validation_scope(mocker, scopes):
         "fastapi_cloudauth.verification.jwt.get_unverified_claims",
         return_value={"dummy key": scopes},
     )
-    verifier = ScopedAuth(jwks=JWKS(keys=[]))
+    verifier = ScopedAuth(jwks=JWKS.null())
     scope_key = "dummy key"
     verifier.scope_key = scope_key
 
@@ -88,7 +86,7 @@ async def test_forget_def_user_info(auth):
         credentials="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Im5hbWUiLCJpYXQiOjE1MTYyMzkwMjJ9.3ZEDmhWNZWDbJDPDlZX_I3oaalNYXdoT-bKLxIxQK4U",
     )
     """If `.user_info` is None, return raw payload"""
-    get_current_user = auth(jwks=JWKS(keys=[]))
+    get_current_user = auth(jwks=JWKS.null())
     assert get_current_user.user_info is None
     res = await get_current_user.call(dummy_http_auth)
     assert res == {"sub": "1234567890", "name": "name", "iat": 1516239022}
@@ -121,7 +119,7 @@ async def test_assign_user_info(auth):
         credentials="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Im5hbWUiLCJpYXQiOjE1MTYyMzkwMjJ9.3ZEDmhWNZWDbJDPDlZX_I3oaalNYXdoT-bKLxIxQK4U",
     )
 
-    user = auth(jwks=JWKS(keys=[]), user_info=IatSchema)
+    user = auth(jwks=JWKS.null(), user_info=IatSchema)
     assert await user.call(dummy_http_auth) == IatSchema(iat=1516239022)
 
     assert await user.claim(SubSchema).call(dummy_http_auth) == SubSchema(
@@ -146,11 +144,11 @@ async def test_extract_raw_user_info(auth):
     class NameSchema(BaseModel):
         name: str
 
-    get_current_user = auth(jwks=JWKS(keys=[]), user_info=NameSchema)
+    get_current_user = auth(jwks=JWKS.null(), user_info=NameSchema)
     get_current_user.user_info = None
     res = await get_current_user.call(dummy_http_auth)
     assert res == {"sub": "1234567890", "name": "name", "iat": 1516239022}
 
-    get_current_user = auth(jwks=JWKS(keys=[]), user_info=NameSchema)
+    get_current_user = auth(jwks=JWKS.null(), user_info=NameSchema)
     res = await get_current_user.claim(None).call(dummy_http_auth)
     assert res == {"sub": "1234567890", "name": "name", "iat": 1516239022}

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -50,6 +50,17 @@ async def test_malformed_token_handling():
     assert not await verifier.verify_token(http_auth_with_malformed_token)
 
 
+@pytest.mark.asyncio
+async def test_jwks_test_mode():
+    # instantiate null jwks obj (no querying jwks)
+    _jwks = JWKS.null()
+
+    # instantiate fixed jwks obj (no querying jwks)
+    dummy = Key(None, None)
+    _jwks = JWKS(fixed_keys={"test": dummy})
+    assert await _jwks.get_publickey("test") == dummy
+
+
 class DummyResp(Response):
     def __init__(self, expires: datetime) -> None:
         super().__init__()


### PR DESCRIPTION
Refactoring and add tests for PR(#60) to fix issue(#59).
(Create new PR to run CI with environment variables in main repository)

Adds:

- (For Firebase Authorization), store JWKS expires and refresh them when they expired. For other providers, nothing changs.

Breaking changes:

- Drop classmethod to instantiate JWKS, and turned to implement parse method on custom JWKS for each provider.
- Token verification turned to be async function