### PR TITLE
Fix dependency for Firebase: auto-install cryptography with python-jose

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 fastapi = ">= 0.60.1, < 1.0"
-python-jose = "^3.2.0"
+python-jose = {version = ">=3.3.0,<4.0.0", extras = ["cryptography"]}
 requests = "^2.24.0"
 
 [tool.poetry.dev-dependencies]

--- a/scripts/dep.sh
+++ b/scripts/dep.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# check dependency problem via install fastapi-cloudauth with wheel
+set -e
+
+poetry build
+python3 -m venv env
+source env/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install wheel dist/fastapi_cloudauth-*.whl
+
+# if not installed cryptography with python-jose, this line fails
+python3 -c 'from fastapi_cloudauth.firebase import *; print(JWKS(url="https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"))'
+echo "Success"


### PR DESCRIPTION
Fix dependency problem for Firebase Auth.
Related to #33 #48 #51 

To integrate Firebase Auth requires `cryptography`. that's is installed in `Poetry` development environments but not in production environment (when call `pip install fastapi-cloudauth`).

Fix:

- Add cryptography in dependency
- upgrade `python-jose[cryptography]` to match `FastAPI` dev dependencies