### PR TITLE
fix moved ValidationError import

### DIFF
--- a/fastapi_cloudauth/base.py
+++ b/fastapi_cloudauth/base.py
@@ -5,8 +5,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import jwt
-from pydantic import BaseModel
-from pydantic.error_wrappers import ValidationError
+from pydantic import BaseModel, ValidationError
 from starlette import status
 
 from fastapi_cloudauth.messages import NOT_AUTHENTICATED, NOT_VALIDATED_CLAIMS


### PR DESCRIPTION
Seeing warning:
```
/usr/local/lib/python3.12/site-packages/fastapi_cloudauth/__init__.py:1: in <module>
    from .auth0 import Auth0, Auth0CurrentUser
/usr/local/lib/python3.12/site-packages/fastapi_cloudauth/auth0.py:10: in <module>
    from .base import ScopedAuth, UserInfoAuth
/usr/local/lib/python3.12/site-packages/fastapi_cloudauth/base.py:9: in <module>
    from pydantic.error_wrappers import ValidationError
/usr/local/lib/python3.12/site-packages/pydantic/_migration.py:283: in wrapper
    warnings.warn(f'`{import_path}` has been moved to `{new_location}`.')
E   UserWarning: `pydantic.error_wrappers:ValidationError` has been moved to `pydantic:ValidationError`.
```

The warning comes from here, where we can see the error was migrated: https://github.com/pydantic/pydantic/blob/60f704721a096dced3b19dd465a1e31495fcd802/pydantic/_migration.py#L8

Tested by importing directly in a repl:
```
root@a593d9b66d24:/goliath/backend/app# python3
Python 3.12.6 (main, Sep 27 2024, 06:10:24) [GCC 12.2.0] on linux
>>> from pydantic import ValidationError
```

The only part I'm unsure about - do we need to pin pydantic to >2 in this repo?